### PR TITLE
[git] add autoSetupRemote

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -8,4 +8,5 @@
 	excludesfile = ~/.gitignore_global
 [init]
 	defaultBranch = main
-
+[push]
+	autoSetupRemote = true


### PR DESCRIPTION
gitでupstreamを未設定のブランチをpushするときに、自動的に自分のブランチ名と同じリモートブランチを自動的に設定