### PR TITLE
add url.insteadOf

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -11,3 +11,5 @@
 [push]
 	autoSetupRemote = true
 	default = current
+[url "git@github.com:"]
+	insteadOf = https://github.com/


### PR DESCRIPTION
https://github.com/で始まるリポジトリをgit@github.com:に読み替えてくれる設定を追加